### PR TITLE
Fix a typo in the recipes for leather backpack

### DIFF
--- a/src/main/java/ruiseki/omoshiroikamo/common/recipe/BlockRecipes.java
+++ b/src/main/java/ruiseki/omoshiroikamo/common/recipe/BlockRecipes.java
@@ -31,11 +31,11 @@ public class BlockRecipes {
                     "SCS",
                     "LLL",
                     'S',
-                    new ItemStack(Items.string, 1, 1),
+                    new ItemStack(Items.string, 1, 0),
                     'L',
                     "itemLeather",
                     'C',
-                    new ItemStack(Blocks.chest, 1, 1)));
+                    new ItemStack(Blocks.chest, 1, 0)));
 
             // Iron Backpack
             GameRegistry.addRecipe(


### PR DESCRIPTION
## Describe your changes

Tiny change to make it require string and chest without metadata. Before it wanted a String with metadata of 1 for crafting, and same for the chest, with this change it requires a metadata of both to 0 in the recipe (vanilla item and craftable). This way the (new) leather backpack is now craftable

## Issue or Enhancement ticket number and link

https://github.com/Shigure-Ruiseki/OmoshiroiKamo/issues/64

## Checklist before requesting a review
- [yes ] I have performed a complete self-review of my code (format, style, logic).
- [yes ] I have added tests or verified that no new tests are required.
- [yes ] I have updated documentation or release notes if necessary.
